### PR TITLE
Add an option to compress the created executable with UPX

### DIFF
--- a/.github/workflows/upx.yaml
+++ b/.github/workflows/upx.yaml
@@ -1,0 +1,24 @@
+name: upx
+
+on: [push, pull_request]
+
+jobs:
+  upx:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Docker login
+      env:
+        TOKEN: ${{ secrets.PAT_GHCR }}
+        USERNAME: ${{ github.repository_owner }}
+      run: echo $TOKEN | docker login ghcr.io -u $USERNAME --password-stdin
+    - name: Create docker image with a UPX compressed executable
+      run: export UPX_COMPRESSION="--best"; sbt docker
+    - name: Publish docker image to ghcr.io
+      run: sbt dockerPush

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 FROM oracle/graalvm-ce:20.1.0-java11 as builder
+ARG upx_compression
 RUN gu install native-image
 RUN curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo && \
-    yum install -y sbt git
+    yum install -y sbt git xz
 COPY . /build
 WORKDIR /build
 RUN curl -L -o musl.tar.gz \
     https://github.com/gradinac/musl-bundle-example/releases/download/v1.0/musl.tar.gz && \
     tar -xvzf musl.tar.gz
 RUN sbt graalvm-native-image:packageBin
+
+RUN if [ -n "${upx_compression}" ]; then \
+      curl -L -o upx-3.96-amd64_linux.tar.xz https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz && \
+      tar -xvf upx-3.96-amd64_linux.tar.xz && \
+      upx-3.96-amd64_linux/upx "$upx_compression" /build/target/graalvm-native-image/graalnative4s; \
+    fi
 
 FROM scratch
 COPY --from=builder /build/target/graalvm-native-image/graalnative4s /server

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 This is a showcase for a combination of purely functional Scala libraries that can be used with GraalVM `native-image` without much effort. It employs [http4s][http4s] for general server functionality, [circe][circe] for JSON processing, [pureconfig] to load runtime configuration, [tapir][tapir] to describe HTTP endpoints and [odin][odin] for logging. Applications that were built with `native-image` have beneficial properties such as a lower memory footprint and fast startup. This makes them suitable for serverless applications.
 
 ### Build
-Use `sbt docker` to build a docker image with the native image binary. You don't need to install anything, the build process downloads all required GraalVM tooling. The [created image][image] will be as minimal as possible by using a multi-stage build.
+Use `sbt docker` to build a docker image with the native image binary. You don't need to install anything besides `docker` and `sbt`, the build process downloads all required GraalVM tooling. The [created image][image] will be as minimal as possible by using a multi-stage build.
+
+You can create an even smaller image by utilizing UPX compression. Use the `UPX_COMPRESSION` environment variable at build time to specify the compression level.
+Please note that while this reduces the size of the image significantly it also [has an impact on startup performance and memory consumption.](./benchmark/upx.md)
+
+Example: `export UPX_COMPRESSION="--best"; sbt docker`
 
 ### Deploy
 This repository contains a [workflow][workflow] that will deploy the created image to Google Cloud Run. You could also use the button below to deploy it to your own GCP account.

--- a/benchmark/memory-consumption.sh
+++ b/benchmark/memory-consumption.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o nounset
+
+while getopts p: opt
+do
+  case $opt in
+    p) PREFIX=$OPTARG;;
+  esac
+done
+
+main() {
+  local server_command server_pid bytes suffix
+  printf '| Binary | Memory [bytes] |\n|:---|---:|\n'
+
+  for suffix in no-upx upx-1 upx-2 upx-3 upx-4 upx-5 upx-6 upx-7 upx-8 upx-9 upx-best upx-brute upx-ultra-brute; do
+    server_command="$PREFIX-$suffix"
+    ./$server_command &> /dev/null &
+    server_pid=$!
+    sleep 2
+    bytes="$(ps_mem -t -p $server_pid)"
+    printf "| %-25s | %10s |\n" $server_command $bytes
+    kill ${server_pid}
+  done
+}
+
+main
+exit 0

--- a/benchmark/time-to-first-response.sh
+++ b/benchmark/time-to-first-response.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o nounset
+
+while getopts s:c: opt
+do
+  case $opt in
+    s) SERVER_COMMAND=$OPTARG;;
+    c) CLIENT_COMMAND=$OPTARG;;
+  esac
+done
+
+main() {
+  local server_pid
+  local tries=500
+
+  ./$SERVER_COMMAND &
+  server_pid=$!
+
+  $CLIENT_COMMAND
+  while [ "$?" -ne 0 ]; do
+    ((tries--))
+    if [ "$tries" -eq 0 ]; then
+      echo "Server not started within timeout"
+      exit 1
+    fi
+    $CLIENT_COMMAND
+  done
+  kill ${server_pid}
+}
+
+main
+exit 0

--- a/benchmark/upx.md
+++ b/benchmark/upx.md
@@ -1,0 +1,73 @@
+# Using UPX compressed executables
+
+The size of the binary that was created with GraalVM `native-image` can be reduced even further by using [UPX][upx]. Compression with UPX has a significant impact on the file size but also incurs a penalty with regards to startup performance and memory consumption. In my test setup, the executable that was compressed with option `--best` was 48 MB smaller than the original file. However, compared to its uncompressed counterpart the startup time of the compressed executable was approximately 300 milliseconds slower. Please see the following sections for more detailed test results.
+
+### Size comparison
+
+I used the uncompressed binary from release v0.3.1 and compressed it with all available UPX compression options:
+
+| Binary | Size [byte] |
+|:---|---:|
+| v0.3.1-no-upx          | 67.712.920 |
+| v0.3.1-upx-1           | 26.456.312 |
+| v0.3.1-upx-2           | 25.614.824 |
+| v0.3.1-upx-3           | 25.240.056 |
+| v0.3.1-upx-4           | 23.903.052 |
+| v0.3.1-upx-5           | 22.732.760 |
+| v0.3.1-upx-6           | 22.413.428 |
+| v0.3.1-upx-7           | 21.868.336 |
+| v0.3.1-upx-8           | 21.603.612 |
+| v0.3.1-upx-9           | 21.335.948 |
+| v0.3.1-upx-best        | 18.757.440 |
+| v0.3.1-upx-brute       | 13.582.308 |
+| v0.3.1-upx-ultra-brute | 13.540.112 |
+
+### Memory comparison
+
+In my test setup, the memory consumption of compressed executables was approximately 70 MB higher because the binary needs to be decompressed on the fly before it is executed. All test results were acquired via this [script][script2].
+
+| Binary | Memory [bytes] |
+|:---|---:|
+| v0.3.1-no-upx             |   66.242.560 |
+| v0.3.1-upx-1              |  140.781.568 |
+| v0.3.1-upx-2              |  140.781.568 |
+| v0.3.1-upx-3              |  140.797.952 |
+| v0.3.1-upx-4              |  140.773.376 |
+| v0.3.1-upx-5              |  140.797.952 |
+| v0.3.1-upx-6              |  140.773.376 |
+| v0.3.1-upx-7              |  140.781.568 |
+| v0.3.1-upx-8              |  140.789.760 |
+| v0.3.1-upx-9              |  140.781.568 |
+| v0.3.1-upx-best           |  140.756.992 |
+| v0.3.1-upx-brute          |  140.806.144 |
+| v0.3.1-upx-ultra-brute    |  141.182.976 |
+
+### Startup performance
+
+I used [hyperfine][hyperfine] in conjunction with [a shell script][script1] to measure the time to the first response of the server executable. The tests were run on a fairly outdated Lenovo X220 laptop (Intel Core i7-2640M, 16 GB RAM). This is the hyperfine command line that measured the results further down below:
+
+```
+hyperfine -r 50 -L compression no-upx,upx-best,upx-9,upx-8,upx-7,upx-6,upx-5,upx-4,upx-3,upx-2,upx-1,upx-brute,upx-ultra-brute './time-to-first-response.sh -s v0.3.1-{compression} -c "curl localhost:8080/hello"'
+```
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `./time-to-first-response.sh -s v0.3.1-no-upx -c "curl localhost:8080/hello"`          | 41.5 ± 10.7   | 22.8   | 63.6   | 1.00         |
+| `./time-to-first-response.sh -s v0.3.1-upx-1 -c "curl localhost:8080/hello"`           | 375.9 ± 22.4  | 328.3  | 422.7  | 9.05 ± 2.38  |
+| `./time-to-first-response.sh -s v0.3.1-upx-2 -c "curl localhost:8080/hello"`           | 372.4 ± 23.9  | 334.3  | 449.8  | 8.96 ± 2.37  |
+| `./time-to-first-response.sh -s v0.3.1-upx-3 -c "curl localhost:8080/hello"`           | 367.8 ± 17.2  | 329.1  | 405.1  | 8.85 ± 2.31  |
+| `./time-to-first-response.sh -s v0.3.1-upx-4 -c "curl localhost:8080/hello"`           | 355.9 ± 18.5  | 320.9  | 400.1  | 8.57 ± 2.24  |
+| `./time-to-first-response.sh -s v0.3.1-upx-5 -c "curl localhost:8080/hello"`           | 336.3 ± 19.7  | 299.7  | 375.9  | 8.10 ± 2.13  |
+| `./time-to-first-response.sh -s v0.3.1-upx-6 -c "curl localhost:8080/hello"`           | 336.0 ± 19.8  | 295.4  | 368.1  | 8.09 ± 2.13  |
+| `./time-to-first-response.sh -s v0.3.1-upx-7 -c "curl localhost:8080/hello"`           | 326.3 ± 19.9  | 284.8  | 360.6  | 7.86 ± 2.07  |
+| `./time-to-first-response.sh -s v0.3.1-upx-8 -c "curl localhost:8080/hello"`           | 316.5 ± 22.0  | 283.2  | 368.3  | 7.62 ± 2.02  |
+| `./time-to-first-response.sh -s v0.3.1-upx-9 -c "curl localhost:8080/hello"`           | 315.2 ± 19.6  | 273.5  | 358.3  | 7.59 ± 2.00  |
+| `./time-to-first-response.sh -s v0.3.1-upx-best -c "curl localhost:8080/hello"`        | 330.7 ± 19.7  | 285.4  | 375.8  | 7.96 ± 2.10  |
+| `./time-to-first-response.sh -s v0.3.1-upx-brute -c "curl localhost:8080/hello"`       | 1144.4 ± 26.3 | 1098.4 | 1236.2 | 27.55 ± 7.09 |
+| `./time-to-first-response.sh -s v0.3.1-upx-ultra-brute -c "curl localhost:8080/hello"` | 1198.6 ± 22.4 | 1155.3 | 1246.2 | 28.85 ± 7.42 |
+
+
+[hyperfine]: https://github.com/sharkdp/hyperfine
+[upx]: https://github.com/upx/upx
+[script1]: ./time-to-first-response.sh
+[script2]: ./memory-consumption.sh

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ val v = new {
   val munitCE    = "0.12.0"
 }
 
+val upx = "UPX_COMPRESSION"
+
 lazy val graalnative4s = project
   .in(file("."))
   .enablePlugins(BuildInfoPlugin, sbtdocker.DockerPlugin, GraalVMNativeImagePlugin)
@@ -46,12 +48,15 @@ lazy val graalnative4s = project
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     docker / dockerfile := NativeDockerfile(file("Dockerfile")),
-    docker / imageNames := Seq(ImageName(s"ghcr.io/usommerl/${name.value}:${dockerImageTag}"))
+    docker / imageNames := Seq(ImageName(s"ghcr.io/usommerl/${name.value}:${dockerImageTag}")),
+    docker / dockerBuildArguments := sys.env.get(upx).map(s => Map("upx_compression" -> s)).getOrElse(Map.empty)
   )
 
 def dockerImageTag: String = {
   import sys.process._
   val regex       = """v\d+\.\d+\.\d+""".r.regex
   val versionTags = "git tag --points-at HEAD".!!.trim.split("\n").filter(_.matches(regex))
-  versionTags.sorted(Ordering.String.reverse).headOption.map(_.replace("v", "")).getOrElse("latest")
+  val version     = versionTags.sorted(Ordering.String.reverse).headOption.map(_.replace("v", "")).getOrElse("latest")
+  val upxSuffix   = sys.env.get(upx).map(s => s"-upx${s.replace("--", "-")}").getOrElse("")
+  s"$version$upxSuffix"
 }


### PR DESCRIPTION
This PR enables you to build docker images that compress the executable with [UPX][upx]. I've also included a couple of [test results that compare compressed and uncompressed executables.][tests]

Closes: #37 


[upx]: https://github.com/upx/upx
[tests]: https://github.com/usommerl/graalnative4s/blob/562fea0/benchmark/upx.md